### PR TITLE
CI: Deployment

### DIFF
--- a/.github/workflows/deploy-to-canary.yml
+++ b/.github/workflows/deploy-to-canary.yml
@@ -1,0 +1,59 @@
+name: deployToCanary
+
+
+on:
+  workflow_dispatch: {}
+
+jobs:
+  DeployToCanary:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: sa-east-1
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+
+      - name: Build, tag, and push the image to Amazon ECR
+        id: build-image
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REPOSITORY: ${{ secrets.REPO_NAME }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "Building image..."
+          docker build --build-arg GITHUB_TOKEN -t $ECR_REGISTRY/$ECR_REPOSITORY:$GITHUB_SHA .
+          echo "Pushing image to ECR..."
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$GITHUB_SHA
+
+
+      - name: Setup git ssh key
+        uses: webfactory/ssh-agent@v0.5.4
+        with:
+            ssh-private-key: ${{ secrets.SSH_KEY }}
+
+      - name: Setup git as a Github Actions user
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+
+      - name: push to our repos
+        run: |
+          git tag canary -f && git push origin canary -f
+          bash <(curl -s https://raw.githubusercontent.com/budproj/gist/main/gitops/deploy.sh) -t $GITHUB_SHA -s canary}
+
+# TODO: generate an ARGOCD_TOKEN
+      # - name: Sync ArgoCD Application
+      #   uses: omegion/argocd-app-actions@master
+      #   with:
+      #     address: ${{ secrets.ARGOCD_ADDRESS }}
+      #     token: ${{ secrets.ARGOCD_TOKEN }}
+      #     appName: ${{ secrets.REPO_NAME }}

--- a/.github/workflows/deploy-to-canary.yml
+++ b/.github/workflows/deploy-to-canary.yml
@@ -3,9 +3,6 @@ name: deployToCanary
 
 on:
   workflow_dispatch: {}
-  push: # remove on release
-    branches:
-      - feat/deployment
 
 jobs:
   DeployToCanary:

--- a/.github/workflows/deploy-to-canary.yml
+++ b/.github/workflows/deploy-to-canary.yml
@@ -3,6 +3,10 @@ name: deployToCanary
 
 on:
   workflow_dispatch: {}
+  push:
+    branches:
+      - main
+      - feat/deployment
 
 jobs:
   DeployToCanary:

--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-      - feat/deployment # remove on release
 
 jobs:
   DeployToProduction:

--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -1,14 +1,14 @@
-name: deployToCanary
+name: deployToProduction
 
 
 on:
   push:
     branches:
       - main
-      - feat/deployment
+      - feat/deployment # remove on release
 
 jobs:
-  DeployToCanary:
+  DeployToProduction:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -51,7 +51,7 @@ jobs:
       - name: push to our repos
         run: |
           git tag stable -f && git push origin stable -f
-          bash <(curl -s https://raw.githubusercontent.com/budproj/gist/main/gitops/deploy.sh) -t $GITHUB_SHA -s stable}
+          bash <(curl -s https://raw.githubusercontent.com/budproj/gist/main/gitops/deploy.sh) -t $GITHUB_SHA -s stable
 
 # TODO: generate an ARGOCD_TOKEN
       # - name: Sync ArgoCD Application

--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -2,9 +2,9 @@ name: deployToCanary
 
 
 on:
-  workflow_dispatch: {}
-  push: # remove on release
+  push:
     branches:
+      - main
       - feat/deployment
 
 jobs:
@@ -50,8 +50,8 @@ jobs:
 
       - name: push to our repos
         run: |
-          git tag canary -f && git push origin canary -f
-          bash <(curl -s https://raw.githubusercontent.com/budproj/gist/main/gitops/deploy.sh) -t $GITHUB_SHA -s canary}
+          git tag stable -f && git push origin stable -f
+          bash <(curl -s https://raw.githubusercontent.com/budproj/gist/main/gitops/deploy.sh) -t $GITHUB_SHA -s stable}
 
 # TODO: generate an ARGOCD_TOKEN
       # - name: Sync ArgoCD Application

--- a/manifests/canary/canary-deployment.yml
+++ b/manifests/canary/canary-deployment.yml
@@ -1,0 +1,41 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: notifications-microservice-canary
+  labels:
+    app.kubernetes.io/name: notifications-microservice-canary
+    app.kubernetes.io/part-of: application-layer
+    app.kubernetes.io/component: microservice-application
+    app.kubernetes.io/version: 1.0.0
+spec:
+  revisionHistoryLimit: 0
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: notifications-microservice-canary
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: notifications-microservice-canary
+        app.kubernetes.io/part-of: application-layer
+        app.kubernetes.io/component: microservice-application
+        app.kubernetes.io/version: 1.0.0
+    spec:
+      containers:
+        - name: notifications-microservice
+          image: 904333181156.dkr.ecr.sa-east-1.amazonaws.com/notifications-microservice:$ECR_TAG
+          ports:
+            - containerPort: 80
+          env:
+            - name: PORT
+              value: '80'
+
+            - name: NATS_CONNECTION_STRING
+              value: nats://nats.nats.svc.cluster.local:4222
+
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: notifications-microservice
+                  key: database-url

--- a/manifests/canary/canary-deployment.yml
+++ b/manifests/canary/canary-deployment.yml
@@ -39,3 +39,6 @@ spec:
                 secretKeyRef:
                   name: notifications-microservice
                   key: database-url
+
+            - name: AUTHZ_ISSUER
+              value: https://getbud.us.auth0.com/

--- a/manifests/canary/canary-deployment.yml
+++ b/manifests/canary/canary-deployment.yml
@@ -32,7 +32,7 @@ spec:
               value: '80'
 
             - name: NATS_CONNECTION_STRING
-              value: nats://nats.nats.svc.cluster.local:4222
+              value: nats://nats-canary.nats.svc.cluster.local:4222
 
             - name: DATABASE_URL
               valueFrom:

--- a/manifests/canary/canary-service.yml
+++ b/manifests/canary/canary-service.yml
@@ -1,0 +1,18 @@
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: notifications-microservice-canary
+  labels:
+    app.kubernetes.io/name: notifications-microservice-canary
+    app.kubernetes.io/part-of: application-layer
+    app.kubernetes.io/component: backend-application
+    app.kubernetes.io/version: 1.0.0
+spec:
+  selector:
+    app.kubernetes.io/name: notifications-microservice-canary
+  ports:
+    - name: http
+      port: 80
+      targetPort: 80
+      protocol: TCP

--- a/manifests/ingress-route.yml
+++ b/manifests/ingress-route.yml
@@ -1,0 +1,43 @@
+---
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRoute
+metadata:
+  name: notifications-microservice
+  labels:
+    app.kubernetes.io/name: business
+    app.kubernetes.io/part-of: application-layer
+    app.kubernetes.io/component: ingress-route
+    app.kubernetes.io/version: 1.0.0
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - match: Host(`notifications.getbud.co`)
+      kind: Rule
+      middlewares:
+        - name: websocket-middleware # This allows https upgrade to wss
+      services:
+        - name: notifications-websocket-stable
+          port: 80
+    - match: Host(`notifications.canary.getbud.co`)
+      kind: Rule
+      middlewares:
+        - name: websocket-middleware # This allows https upgrade to wss
+      services:
+        - name: notifications-websocket-canary
+          port: 80
+  tls:
+    certResolver: letsencrypt
+    options:
+      minVersion: VersionTLS12
+
+
+---
+apiVersion: traefik.containo.us/v1alpha1
+kind: Middleware
+metadata:
+  name: websocket-middleware
+spec:
+  headers:
+    customRequestHeaders:
+      X-Forwarded-Proto: "https"

--- a/manifests/ingress-route.yml
+++ b/manifests/ingress-route.yml
@@ -4,7 +4,7 @@ kind: IngressRoute
 metadata:
   name: notifications-microservice
   labels:
-    app.kubernetes.io/name: business
+    app.kubernetes.io/name: notifications-microservice
     app.kubernetes.io/part-of: application-layer
     app.kubernetes.io/component: ingress-route
     app.kubernetes.io/version: 1.0.0
@@ -17,14 +17,14 @@ spec:
       middlewares:
         - name: websocket-middleware # This allows https upgrade to wss
       services:
-        - name: notifications-websocket-stable
+        - name: notifications-microservice-stable
           port: 80
     - match: Host(`notifications.canary.getbud.co`)
       kind: Rule
       middlewares:
         - name: websocket-middleware # This allows https upgrade to wss
       services:
-        - name: notifications-websocket-canary
+        - name: notifications-microservice-canary
           port: 80
   tls:
     certResolver: letsencrypt

--- a/manifests/stable/deployment.yml
+++ b/manifests/stable/deployment.yml
@@ -1,0 +1,43 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: notifications-microservice-stable
+  labels:
+    app.kubernetes.io/name: notifications-microservice-stable
+    app.kubernetes.io/part-of: application-layer
+    app.kubernetes.io/component: backend-application
+    app.kubernetes.io/version: 1.0.0
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: notifications-microservice-stable
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: notifications-microservice-stable
+        app.kubernetes.io/part-of: application-layer
+        app.kubernetes.io/component: backend-application
+        app.kubernetes.io/version: 1.0.0
+    spec:
+      containers:
+        - name: notifications-microservice
+          image: 904333181156.dkr.ecr.sa-east-1.amazonaws.com/notifications-microservice:$ECR_TAG
+          ports:
+            - containerPort: 80
+          env:
+            - name: PORT
+              value: '80'
+
+            - name: NATS_CONNECTION_STRING
+              value: nats://nats.nats.svc.cluster.local:4222
+            
+            - name: DATABASE_URL
+              value: postgresql://notifications:changeme@localhost:5432/notifications?schema=public # todo
+
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: notifications-microservice-canary
+                  key: database-url

--- a/manifests/stable/deployment.yml
+++ b/manifests/stable/deployment.yml
@@ -38,3 +38,6 @@ spec:
                 secretKeyRef:
                   name: notifications-microservice-canary
                   key: database-url
+
+            - name: AUTHZ_ISSUER
+              value: https://getbud.us.auth0.com/

--- a/manifests/stable/deployment.yml
+++ b/manifests/stable/deployment.yml
@@ -32,9 +32,6 @@ spec:
 
             - name: NATS_CONNECTION_STRING
               value: nats://nats.nats.svc.cluster.local:4222
-            
-            - name: DATABASE_URL
-              value: postgresql://notifications:changeme@localhost:5432/notifications?schema=public # todo
 
             - name: DATABASE_URL
               valueFrom:

--- a/manifests/stable/service.yml
+++ b/manifests/stable/service.yml
@@ -2,15 +2,15 @@
 kind: Service
 apiVersion: v1
 metadata:
-  name: integrations-microservice-stable
+  name: notifications-microservice-stable
   labels:
-    app.kubernetes.io/name: integrations-microservice-stable
+    app.kubernetes.io/name: notifications-microservice-stable
     app.kubernetes.io/part-of: application-layer
     app.kubernetes.io/component: service
     app.kubernetes.io/version: 1.0.0
 spec:
   selector:
-    app.kubernetes.io/name: integrations-microservice-stable
+    app.kubernetes.io/name: notifications-microservice-stable
   ports:
     - name: http
       port: 80

--- a/manifests/stable/service.yml
+++ b/manifests/stable/service.yml
@@ -1,0 +1,18 @@
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: integrations-microservice-stable
+  labels:
+    app.kubernetes.io/name: integrations-microservice-stable
+    app.kubernetes.io/part-of: application-layer
+    app.kubernetes.io/component: service
+    app.kubernetes.io/version: 1.0.0
+spec:
+  selector:
+    app.kubernetes.io/name: integrations-microservice-stable
+  ports:
+    - name: http
+      port: 80
+      targetPort: 80
+      protocol: TCP

--- a/test/e2e/db-healthcheck.test.ts
+++ b/test/e2e/db-healthcheck.test.ts
@@ -9,7 +9,7 @@ import { join as pathJoin } from 'node:path';
 import { PrismaClient } from '@prisma/client';
 
 describe('NATS Health Check', () => {
-  jest.setTimeout(1_000_000);
+  jest.setTimeout(120_000);
 
   let natsConnection: NatsConnection;
   let dbConnection: PrismaClient;

--- a/test/e2e/nats-healthcheck.test.ts
+++ b/test/e2e/nats-healthcheck.test.ts
@@ -8,7 +8,7 @@ import { randomUUID } from 'node:crypto';
 import { join as pathJoin } from 'node:path';
 
 describe('NATS Health Check', () => {
-  jest.setTimeout(1_000_000);
+  jest.setTimeout(120_000);
 
   let natsConnection: NatsConnection;
   let dockerComposeEnvironment: StartedDockerComposeEnvironment;

--- a/test/e2e/ws-healthcheck.test.ts
+++ b/test/e2e/ws-healthcheck.test.ts
@@ -7,7 +7,7 @@ import {
 } from 'testcontainers';
 
 describe('Healthcheck messages', () => {
-  jest.setTimeout(1_000_000);
+  jest.setTimeout(120_000);
 
   let clientSocket: Socket;
   let dockerComposeEnvironment: StartedDockerComposeEnvironment;


### PR DESCRIPTION
## 🎢 Motivation

Adds deploy to canary and stable environments.

## 🔧 Solution

Implements manifests files and github actions to deliver these files (and docker image) to the cluster.

- [x] Manifest production files
- [x] Manifest canary files
- [x] Github action to canary
- [x] Create RDS database in terraform project: budproj/platform#31
- [x] Manifest files in k8s-manifests project
- [x] Github action to production

## 🚨  Testing

Try to connect, via websockets, to the service through:
- [x] `notifications.canary.getbud.co`
- [x] `notifications.getbud.co`

## 🃏 Task Card

Link to issue on Jira

- [`BUD22-374`](https://getbud.atlassian.net/browse/BUD22-374)

## 🔗 Related PRs

This PR is related to some other PRs in different services, they are:

- [`project#PR_NUMBER`](https://)

## 🍩 Validation

Who tested this PR?

### Canary

- [ ] Marcelo
- [ ] Gustavo
- [ ] Aline

### Dev

- [ ] Perin
- [ ] Guilherme
- [ ] Rodrigo
- [ ] Diego
